### PR TITLE
Pass munki_update_name to the UpdateInfoProvider

### DIFF
--- a/MSOffice2011Updates/MSOffice2011Updates-DisabledAllQuit.pkg.recipe
+++ b/MSOffice2011Updates/MSOffice2011Updates-DisabledAllQuit.pkg.recipe
@@ -30,6 +30,8 @@ http://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx for a table of Cu
             <dict>
                 <key>culture_code</key>
                 <string>%CULTURE_CODE%</string>
+                <key>munki_update_name</key>
+                <string>%NAME%</string>
                 <key>version</key>
                 <string>%VERSION%</string>
             </dict>


### PR DESCRIPTION
If munki_update_name is not passed to MSOffice2011UpdateInfoProvider, it always uses the default name and cannot be overridden.  Mirrors behaviour found in the base autopkg recipe.